### PR TITLE
BellNotification의 전체삭제 버튼 button태그로 임시수정

### DIFF
--- a/src/components/layout/Header/Notification/BellNotifications.jsx
+++ b/src/components/layout/Header/Notification/BellNotifications.jsx
@@ -1,4 +1,3 @@
-import Button from 'components/common/Button/Button';
 import styles from './BellNotifications.module.css';
 
 import Notification from 'components/layout/Header/Notification/Notification';
@@ -69,16 +68,12 @@ function BellNotifications() {
             <div className={styles.topArea}>
                 <div className={styles.title}>알림</div>
                 <div className={styles.allDeleteBtn}>
-                    <Button
-                        size="small"
-                        text="전체 삭제"
-                        onClick={handleDeleteAll}
-                    />
+                    <button onClick={handleDeleteAll}>전체 삭제</button>
                 </div>
             </div>
             <div className={styles.bottomArea}>
                 {data.length === 0 ? (
-                    <p>알림이 없습니다.</p>
+                    <p className={styles.p}>알림이 없습니다.</p>
                 ) : (
                     data.map((notice, noticeIndex) => (
                         <Notification

--- a/src/components/layout/Header/Notification/BellNotifications.module.css
+++ b/src/components/layout/Header/Notification/BellNotifications.module.css
@@ -31,7 +31,7 @@
     display: flex;
     justify-content: baseline;
 }
-p {
+.p {
     margin-bottom: 1rem;
 }
 .allDeleteBtn {


### PR DESCRIPTION
BellNotification.jsx 컴포넌트의 Button 컴포넌트 사용을 button태그로 임시수정
```
<div className={styles.notificationsArea}>
            <div className={styles.topArea}>
                <div className={styles.title}>알림</div>
                <div className={styles.allDeleteBtn}>
                    <button onClick={handleDeleteAll}>전체 삭제</button>
                </div>
            </div>
            <div className={styles.bottomArea}>
                {data.length === 0 ? (
                    <p className={styles.p}>알림이 없습니다.</p>
                ) : (
                    data.map((notice, noticeIndex) => (
                        <Notification
                            key={noticeIndex}
                            category={notice.category}
                            data={notice}
                            handleDelete={() =>
                                handleNoticeDelete(notice.noticeId)
                            }
                        />
                    ))
                )}
            </div>
        </div>
```
<hr/>

css에서는 p태그로 선택되었던 부분 .p로 변경 후 컴포넌트의 p태그에도 className={style.p} 작성
```
// ---- css ----
.p {
    margin-bottom: 1rem;
}
```