### PR TITLE
게시물 상세 페이지 UI 및 기능 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import Header from 'components/layout/Header/Header';
 import Footer from 'components/layout/Footer/Footer';
+import BoardDetail from 'pages/blog/BoardDetailPage/BoardDetail';
 
 function App() {
     return (
@@ -12,6 +13,7 @@ function App() {
                 <Header />
 
                 <div className={styles.layout}>
+                    <BoardDetail/>
                 </div>
 
                 <Footer />

--- a/src/components/blog/Reply/Reply.jsx
+++ b/src/components/blog/Reply/Reply.jsx
@@ -15,7 +15,9 @@ import ReplyEdit from '../ReplyEdit/ReplyEdit';
  * @param {number} replyId 댓글 번호
  * @param {number} [reCommentId] 참조한 댓글 번호
  * @param {object} like 좋아요 수, 클릭여부 (likeCount:0, isLiked:false)
- * @param {onClick} onClick Like컴포넌트에 전달될 onClick이벤트
+ * @param {function} likeOnClick Like컴포넌트에 전달될 onClick이벤트
+ * @param {function} changeReply ReplyEdit컴포넌트에 onClick이벤트 발생 시 실행할 함수
+ * @param {function} addReply ReplyInput컴포넌트에 onClick이벤트 발생 시 실행할 함수
  */
 function Reply({
     nickname,
@@ -25,7 +27,9 @@ function Reply({
     replyId,
     reCommentId,
     like,
-    onClick,
+    likeOnClick,
+    changeReply,
+    addReply,
 }) {
     const replyInputRef = useRef(null);
     const [editIsClicked, setEditIsClicked] = useState(false);
@@ -54,13 +58,23 @@ function Reply({
         answer ? alert('삭제완료!') : alert('삭제 취소');
     }
 
+    const handleEditSubmit = (content) => {
+        setEditIsClicked(false);
+        changeReply(replyId, content);
+    }
+
+    const handleNicknameClick = () => {
+        // 라우터를 통해 nickname 블로그로 이동
+        alert(nickname+'블로그 이동!');
+    }
+
     return (
         <>
             {!editIsClicked &&
                 <div className={`${styles.oneReply} ${reCommentId && styles.reCommentContainer}`}>
                     <div className={styles.replyHeader}>
                         <div className={`${styles.headerdiv} ${reCommentId && styles.reCommentDiv}`}>
-                            <span className={styles.replyWriter}>{nickname}</span>
+                            <span onClick={handleNicknameClick} className={styles.replyWriter}>{nickname}</span>
                             <span className={styles.edit} onClick={handleEditReply}>
                                 <VscEdit />
                             </span>
@@ -90,24 +104,22 @@ function Reply({
                             댓글 달기
                         </div>}
                         <div className={styles.likeBtn}>
-                            <Likes count={like.likeCount} isLiked={like.isLiked} onClick={onClick}/>
+                            {like &&
+                            <Likes count={like.likeCount} isLiked={like.isLiked} onClick={likeOnClick}/>}
                         </div>
                     </div>
                     <hr className={styles.horizon} />
                     <div className={styles.reComment} id={replyId} ref={replyInputRef}>
-                        
                         <div className={styles.arrow}>
                             <VscIndent />
                         </div>
-                        <ReplyInput replyId={replyId} size={'small'} />
+                        <ReplyInput reCommentId={replyId} size={'small'} addReply={addReply}/>
                     </div>
                 </div>
             }
             {editIsClicked && 
                 <div className={styles.editContainer}>
-                    <ReplyEdit content={replyContent} replyId={replyId} nickname={nickname} gender={gender}/>
-                        <button className={styles.editButton}><VscEdit/></button>
-                    
+                    <ReplyEdit content={replyContent} replyId={replyId} nickname={nickname} gender={gender} onClick={handleEditSubmit}/>
                 </div>
             }
         </>

--- a/src/components/blog/Reply/Reply.module.css
+++ b/src/components/blog/Reply/Reply.module.css
@@ -95,12 +95,3 @@
     position: relative;
 }
 
-.editButton {
-    position: absolute;
-    font-size: 4rem;
-    right: 0.5rem;
-    top: 2rem;
-    height: 4.5rem;
-}
-
-

--- a/src/components/blog/ReplyEdit/ReplyEdit.jsx
+++ b/src/components/blog/ReplyEdit/ReplyEdit.jsx
@@ -10,13 +10,18 @@ import { VscEdit } from 'react-icons/vsc';
  * @param {number} replyId 기존 댓글 번호
  * @param {string} nickname 기존 댓글 작성자 닉네임
  * @param {string} gender 기존 댓글 작성자 성별
+ * @param {onClick} onClick 댓글 저장되는 클릭 이벤트
  */
-function ReplyEdit ( {content='', replyId, nickname, gender} ) {
+function ReplyEdit ( {content='', replyId, nickname, gender, onClick} ) {
 
     const [text, setText] = useState(content);
 
     const handleTextarea = (event) => {
         setText(event.target.value);
+    }
+
+    const handleClick = () => {
+        onClick(text);
     }
 
     return (
@@ -33,6 +38,7 @@ function ReplyEdit ( {content='', replyId, nickname, gender} ) {
                 <div className={styles.replyContent}>
                     <textarea className={styles.textarea} value={text} onChange={(event)=>handleTextarea(event)}>
                     </textarea>
+                    <button className={styles.editButton} onClick={handleClick}><VscEdit/></button>
                 </div>
             </div>
             <hr className={styles.horizon} />

--- a/src/components/blog/ReplyEdit/ReplyEdit.module.css
+++ b/src/components/blog/ReplyEdit/ReplyEdit.module.css
@@ -46,3 +46,11 @@
     width: 98%;
     margin-left: 1rem;
 }
+
+.editButton {
+    position: absolute;
+    font-size: 4rem;
+    right: 0.5rem;
+    top: 2rem;
+    height: 4.5rem;
+}

--- a/src/components/blog/ReplyInput/ReplyInput.jsx
+++ b/src/components/blog/ReplyInput/ReplyInput.jsx
@@ -1,6 +1,7 @@
 import { GrSend } from "react-icons/gr";
 import styles from './ReplyInput.module.css';
 import buttons from 'assets/styles/common/button.module.css';
+import { useEffect, useState } from "react";
 
 /**
  * 댓글 입력칸 컴포넌트
@@ -8,21 +9,32 @@ import buttons from 'assets/styles/common/button.module.css';
  * @param {number} boardId 참조할 게시글 번호
  * @param {string} [size] 일반 댓글 입력칸인지 대댓글 입력칸인지 여부 / small : 대댓글
  * @param {number} [reCommentId] 댓글 번호 (대댓글 입력칸일때만 사용)
+ * @param {number} [addReply] 댓글 추가 클릭시 실행되는 함수
  */
-function ReplyInput({ boardId, size, reCommentId=null }) {
-    // 버튼 누르면 댓글 입력 요청 및 입력창 초기화 함수
-    const replyHandler = () => {
-        const text = document.getElementById('reply' + reCommentId);
-        
-        // axios.post('blog/boardDetail/replyInput', { boardId:boardId, replyId:replyId,
-        //                                               token:token, content:content})
+function ReplyInput({ boardId, size, reCommentId=null, addReply }) {
+    const [content, setContent] = useState('');
 
-        text.value = '';
+    // 버튼 누르면 댓글 입력 요청 및 입력창 초기화 함수
+    const replyHandler = async () => {
+        const text = document.getElementById('reply' + reCommentId);
+
+        // const login = axios-token;
+        // if (login) { axios-boardId, reCommentId, content }
+        // const data = axios.post('blog/boardDetail/replyInput', { boardId:boardId, reCommentId:reCommentId, token:token, content:content})
+        // 여기서 data는 서비스단에서 저장 메소드 + 조회 메소드 후 조회한걸 바로 return
+
+        // {nickname:'혱영',date:new Date(2024, 5, 24),gender:'female',content:'놀아',replyId:4,reCommentId:1,likeCount:35,isLiked:false}
+        const data= {
+            nickname:'성중',date:new Date(), gender:'male',content:content,replyId:25,reCommentId:reCommentId,likeCount:0,isLiked:false
+        }
+        addReply(data);
+
+        setContent('');
     };
 
     return (
         <div className={`${styles.replyInputContainer} ${styles[size]}`}>
-            <textarea className={styles.replyInput} id={`reply${reCommentId}`} />
+            <textarea className={styles.replyInput} id={`reply${reCommentId}`} value={content} onChange={e=>setContent(e.target.value)}/>
             <button className={`${buttons.button} ${styles.inputBtn} ${size && styles.reComment}`} onClick={replyHandler}>
                 <GrSend />
             </button>

--- a/src/pages/blog/BoardDetailPage/BoardDetail.jsx
+++ b/src/pages/blog/BoardDetailPage/BoardDetail.jsx
@@ -87,12 +87,22 @@ function BoardDetail() {
         setBoardLike(makeLikeObject(dummyData.likeCount, dummyData.isLiked));
 
         // axios - boardId와 토큰으로 댓글 목록 요청 해야함
-        setReplyList(dummyReply);
         const list = dummyReply.map((item) => 
             makeLikeObject(item.likeCount, item.isLiked, item.replyId)
         );
+        
         setReplyLikeList(list);
+        setReplyList(dummyReply);
+        
     }, [boardId]);
+
+    useEffect(()=>{
+        const list = replyList.map((item) => 
+            makeLikeObject(item.likeCount, item.isLiked, item.replyId)
+        );
+        
+        setReplyLikeList(list);
+    }, [replyList])
 
     const prevImgHandler = () => {
         const count = imgCount === 0 ? boardData.imgList.length - 1 : imgCount - 1;
@@ -139,6 +149,22 @@ function BoardDetail() {
         );
     };
 
+    // 댓글 수정 완료 후 버튼 클릭시 api 수정요청 및 댓글 리렌더링
+    const changeReply = (id, content) => {
+        
+        const changeList = replyList.map((data)=>{
+            if (data.replyId === id) data.content = content; 
+            return data;
+        });        
+
+        // 추후 댓글 수정 api 작성
+        
+        setReplyList(changeList);
+    }
+
+    const addReply = (content) => {
+        setReplyList(prev=>[...prev,content]);
+    }
 
     return (
         <div className={styles.container}>
@@ -201,7 +227,7 @@ function BoardDetail() {
                 }
             </div>
 
-            <ReplyInput boardId={boardData.boardId}/>
+            <ReplyInput boardId={boardData.boardId} addReply={addReply}/>
 
             <div className={styles.replyListContainer}>
                 {replyList && 
@@ -216,7 +242,9 @@ function BoardDetail() {
                             replyContent={parent.content}
                             reCommentId={parent.reCommentId}
                             like={replyLikeList.find(item=>item.replyId === parent.replyId)}
-                            onClick={() => handleReplyLikeClick(parent.replyId)}
+                            likeOnClick={() => handleReplyLikeClick(parent.replyId)}
+                            changeReply={changeReply}
+                            addReply={addReply}
                         />
                         {parent.child.map(child => (
                         <Reply
@@ -228,7 +256,9 @@ function BoardDetail() {
                             replyContent={child.content}
                             reCommentId={child.reCommentId}
                             like={replyLikeList.find(item=>item.replyId === child.replyId)}
-                            onClick={() => handleReplyLikeClick(child.replyId)}
+                            likeOnClick={() => handleReplyLikeClick(child.replyId)}
+                            changeReply={changeReply}
+                            addReply={addReply}
                         />
                         ))}
                     </div>


### PR DESCRIPTION
게시물 상세 페이지 pr 닫힘과 저번 DOM 관련 수정 요청 포함하여 게시물 상세 페이지 재수정 후 pr 올립니다.
어떤 기능 관련한 컴포넌트인지는 이전에 보여드린것과 같습니다.

Reply 
![image](https://github.com/user-attachments/assets/2841450c-26d1-4555-b84b-2d5d8842fa90)

ReplyEdit 
![image](https://github.com/user-attachments/assets/f3ebb7a1-1fea-4fdf-9c34-88b64bc8d787)

ReplyInput
![image](https://github.com/user-attachments/assets/06f0e63b-c024-49d4-a4ec-cf796e351f3a)

+ 좋아요 버튼 클릭 시 숫자 증감 기능



