### PR TITLE
header 비로그인 시 알림 조회되지 않도록 수정

### DIFF
--- a/src/components/layout/Header/Notification/BellNotifications.jsx
+++ b/src/components/layout/Header/Notification/BellNotifications.jsx
@@ -3,12 +3,17 @@ import button from 'assets/styles/common/button.module.css';
 import Notification from 'components/layout/Header/Notification/Notification';
 import { useEffect, useState } from 'react';
 import { getNotification, deleteNotice, deleteNoticeAll } from 'utils/api/headerApi.js';
+import { isLoggedIn } from 'utils/helpers/token.js';
 
 function BellNotifications() {
     const [data, setData] = useState([]);
 
+    
     useEffect(() => {
-        fetchNotification();
+        const token = isLoggedIn();
+        if (token) {
+            fetchNotification();
+        }
     }, []);
 
     const fetchNotification = async () => {


### PR DESCRIPTION
Header의 알림 조회 요청을 로그인 시에만 가능하도록 BellNotification.jsx의 useEffect 수정
```
    useEffect(() => {
        const token = isLoggedIn();
        if (token) {
            fetchNotification();
        }
    }, []);
```